### PR TITLE
CI: Fix standard-version not getting ran

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -18,5 +18,5 @@ jobs:
       - run: npm run build
       - run: git config user.name github-actions
       - run: git config user.email github-actions@github.com
-      - run: standard-version --color=always | awk '! /Run.+to publish/'
+      - run: $(npm bin)/standard-version --color=always | awk '! /Run.+to publish/'
       - run: git push --follow-tags origin master  


### PR DESCRIPTION
## Summary
Standard version was not getting ran in CI. This is because it wasn't in the path. This PR fixes it by prefixing it with the correct path.