### PR TITLE
CI: Add required test step to build release workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -6,7 +6,7 @@ on:
     - master
 
 jobs:
-  build-release:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -15,6 +15,15 @@ jobs:
           node-version: 12
       - run: npm install
       - run: npm test
+
+  build-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm install
       - run: npm run build
       - run: git config user.name github-actions
       - run: git config user.email github-actions@github.com


### PR DESCRIPTION
The build-release workflow was failing to push changes because this repo requires a "test" job to have successfully ran as part of CI before merging. This moves the running the tests out of the "build-release" job and into a separate job called "test" so hopefully GH will accept the push.